### PR TITLE
Fix UCP error

### DIFF
--- a/controller/ajaxify.php
+++ b/controller/ajaxify.php
@@ -208,6 +208,10 @@ class ajaxify
 					'TYPE'	=> 'edit',
 				));
 			}
+		else
+		{
+			trigger_error($this->user->lang['UCP_PROFILE_CONTROL_ERROR']);
+		}
 			break;
 		}
 		$this->template->assign_vars(array(


### PR DESCRIPTION
This commit triggers an error when an user does not have permission (UCP_PROFILE_CONTROL_ERROR) to edit a medal instead of showing L_SUCCESS_EDIT_INFO in case 'edit'.
